### PR TITLE
Add Black-owned businesses section

### DIFF
--- a/data/businesses.ts
+++ b/data/businesses.ts
@@ -1,0 +1,23 @@
+import { CardProps } from "../components/card";
+
+export const BUSINESSES: CardProps[] = [
+  {
+    body: "Resource for finding Black-owned restaurants by region.",
+    title: "Restaurants",
+    href:
+      "https://policingequity.org/images/pdfs-doc/CPE_SoJ_Race-Arrests-UoF_2016-07-08-1130.pdf",
+  },
+  {
+    body: "List of Black-owned independent bookstores.",
+    title: "Bookstores",
+    href:
+      "https://lithub.com/you-can-order-today-from-these-black-owned-independent-bookstores/",
+  },
+  {
+    body:
+      "Spreadsheet for Boston area Black-owned restaurants, stores, and services.",
+    title: "Boston Area",
+    href:
+      "https://docs.google.com/spreadsheets/d/1_wvyIj3w5F8XJn0leuGD5M9sAmaBKT8N2j0fEV0Df5I/",
+  },
+];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,6 +19,7 @@ import {
 import { CHARITIES } from "../data/charities";
 import { EDUCATION } from "../data/education";
 import { CLUBS } from "../data/clubs";
+import { BUSINESSES } from "../data/businesses";
 
 interface HomeProps {
   progress: FundraiserProgress;
@@ -77,7 +78,16 @@ export default function Home({ progress }: HomeProps) {
         ))}
       </div>
       <Header
-        title="3. Spread the Word"
+        title="3. Support Black-Owned Businesses"
+        subtitle="Directly support Black communities by shopping at Black-owned businesses."
+      />
+      <div className="grid gap-10">
+        {BUSINESSES.map((card) => (
+          <Card key={card.title} {...card} />
+        ))}
+      </div>
+      <Header
+        title="4. Spread the Word"
         subtitle="Share the initiative on social media to spread education and demonstrate solidarity."
       />
       <div className="grid gap-8 sm:grid-cols-2 mb-10">


### PR DESCRIPTION
Add links to lists of Black-owned businesses. Supporting Black-owned small businesses is one of the best ways to make a direct impact in our local communities, especially after the economic effects of Coronavirus. I think highlighting some of these businesses would make a great addition to this awesome project!

I've included Bon Appetit's list of lists of Black-owned restaurants around the country, a list of Black-owned bookstores, and a spreadsheet for Boston area restaurants, stores, and services.

I know there are tons of lists out there for every type of business, and I had trouble picking which ones to highlight. It was also difficult as many of the best lists are instagram posts or twitter threads. PLEASE suggest other lists I should search for or links I should add. #BLM